### PR TITLE
Send email to fulfillment provider via Sendgrid

### DIFF
--- a/functions/.env.example
+++ b/functions/.env.example
@@ -4,3 +4,9 @@ STRIPE_PUBLISHABLE_KEY=pk_12345
 STRIPE_SECRET_KEY=sk_12345
 # https://stripe.com/docs/webhooks/signatures
 STRIPE_WEBHOOK_SECRET=whsec_1234
+
+# Sendgrid key
+# https://app.sendgrid.com/settings/api_keys
+SENDGRID_API_KEY=SG.1234
+FROM_EMAIL_ADDRESS=myshop@example.com
+FULFILLMENT_EMAIL_ADDRESS=warehouse@example.com

--- a/functions/package.json
+++ b/functions/package.json
@@ -5,6 +5,7 @@
   "author": "Jason Lengstorf <jason@lengstorf.com> (https://lengstorf.com)",
   "license": "MIT",
   "dependencies": {
+    "@sendgrid/mail": "^7.0.0",
     "stripe": "^8.39.0"
   }
 }


### PR DESCRIPTION
@jlengstorf do you think we should add the Sendgrid specific env vars to the toml file? I deliberately didn't as the webhook piece is optional (you could manually fulfill via the Dashboard for example). Wdyt?